### PR TITLE
Make usable with customize-cra

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ function alias(aliasMap) {
     expandResolveAlias(config.resolve, aliasLocal)
     expandRulesInclude(config.module.rules, Object.values(aliasLocal))
     expandPluginsScope(config.resolve.plugins, Object.values(aliasLocal))
+    return config
   }
 }
 


### PR DESCRIPTION
This change allows alias to be used in conjunction with [customize-cra](https://github.com/arackaf/customize-cra). Its [override function](https://github.com/arackaf/customize-cra#with-webpack) requires, that plugins return the config.