### PR TITLE
Remove import of duplicate method from aliasDangerous.js

### DIFF
--- a/src/aliasDangerous.js
+++ b/src/aliasDangerous.js
@@ -3,7 +3,6 @@ const paths = require('react-scripts/config/paths')
 const {
   configPaths,
   expandResolveAlias,
-  expandRulesInclude,
   expandPluginsScope,
 } = require('./index')
 


### PR DESCRIPTION
This removes an import of `expandRulesInclude` in `aliasDangerous.js` that conflicts with the function `expandRulesInclude` that's declared in that file. Anyone who imports `aliasDangerous` will encounter a `SyntaxError` during the module load. The imported function is never used, and so doesn't need to be imported. Removing the import fixes the `SyntaxError`.

Handles the issue presented in [this comment](https://github.com/oklas/react-app-rewire-alias/issues/3#issuecomment-774559466) in one of the issues.