### PR TITLE
fix(scope): preserve `ModuleScopePlugin.allowedFiles`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,9 @@ function expandPluginsScope(plugins, dirs, files) {
     .map(x => x.constructor.name)
     .indexOf(pluginName)
   if(pluginPos !== -1) {
+    const oldModuleScopePlugin = plugins[pluginPos]
+    const allowedFiles = [...oldModuleScopePlugin.allowedFiles].filter(f => f !== paths.appPackageJson)
+    files.push(...allowedFiles)
     plugins[pluginPos] = new ModuleScopePlugin(dirs, files)
   }
 }


### PR DESCRIPTION
If we are expanding file scopes for plugins, ensure that the
ModuleScopePlugin retains its original entries. This allows us to 
accommodate react-scripts@>=5, which uses webpack@5, which in turn
no longer has in-built shims and hence needs this to be explicitly
given

Fixes #46 